### PR TITLE
Use real async stream for Standard Input

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -21,8 +21,9 @@ namespace FollowingFileStream
         {
             using (var source = new FileStream(InputPath, FileMode.Create, FileAccess.Write, FileShare.Read))
             using (var sw = new StreamWriter(source))
+            using (var sr = new StreamReader(Console.OpenStandardInput()))
             {
-                await Console.In.CopyToAsync(sw, stopOn:"quit");
+                await sr.CopyToAsync(sw, stopOn:"quit");
             }
         }
         private static async Task CopyToOutput()


### PR DESCRIPTION
The TextReader exposed via Console.In only supports synchronous operations, what leads to the blocking situation until the first text is validated.
Replace it by a dedicated and async-capable StreamReader over the StandardInput stream.